### PR TITLE
Initialize FastAPI project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # http_service
+
+Simple FastAPI-based HTTP service.
+
+## Development
+
+Install dependencies with:
+
+```bash
+pip install -e .[test]
+```
+
+Run the tests:
+
+```bash
+pytest
+```
+
+Start the development server:
+
+```bash
+uvicorn http_service.main:app --reload
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "http-service"
+version = "0.1.0"
+description = "A simple FastAPI HTTP service."
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "httpx",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["src"]

--- a/src/http_service/__init__.py
+++ b/src/http_service/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP service package."""
+
+__all__ = ["app"]
+
+from .main import app

--- a/src/http_service/main.py
+++ b/src/http_service/main.py
@@ -1,0 +1,11 @@
+"""Application entry point for the HTTP service."""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Return a friendly welcome message."""
+    return {"message": "Hello, World!"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,15 @@
+"""Tests for the HTTP service."""
+
+from fastapi.testclient import TestClient
+
+from http_service.main import app
+
+
+client = TestClient(app)
+
+
+def test_read_root() -> None:
+    """The root endpoint returns a welcome message."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, World!"}


### PR DESCRIPTION
## Summary
- scaffold FastAPI application with root endpoint and tests
- add pyproject configuration and development instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894a343d488832d9eac1a52d010f7d1